### PR TITLE
Read ExposedPorts from Config, not ContainerConfig

### DIFF
--- a/2.0/test/run
+++ b/2.0/test/run
@@ -16,7 +16,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 
 # Read exposed port from image meta data
-test_port="$(docker inspect --format='{{range $key, $value := .ContainerConfig.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
+test_port="$(docker inspect --format='{{range $key, $value := .Config.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
 
 info() {
   echo -e "\n\e[1m[INFO] $@...\e[0m\n"

--- a/2.2/test/run
+++ b/2.2/test/run
@@ -16,7 +16,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 
 # Read exposed port from image meta data
-test_port="$(docker inspect --format='{{range $key, $value := .ContainerConfig.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
+test_port="$(docker inspect --format='{{range $key, $value := .Config.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
 
 info() {
   echo -e "\n\e[1m[INFO] $@...\e[0m\n"


### PR DESCRIPTION
`.ContainerConfig.ExposedPorts` does not exist in `docker inspect` output of a recent docker tool. `.Config.ExposedPorts` seems to work in all currently used versions.